### PR TITLE
Bump version to PHP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Warning!
+
+Php 8 support is experimental.
+
+
 # PHP Bloom Filter
 
 A Bloom filter is a space-efficient probabilistic data structure, conceived by Burton Howard Bloom in 1970,

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
         }
     ],
     "require": {
-        "php": "~7.0"
+        "php": "^7.2 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/BloomFilterTest.php
+++ b/tests/BloomFilterTest.php
@@ -4,6 +4,7 @@ namespace RocketLabs\BloomFilter\Test\Hash;
 
 use PHPUnit\Framework\TestCase;
 use RocketLabs\BloomFilter\BloomFilter;
+use RocketLabs\BloomFilter\Exception\NotInitialized;
 use RocketLabs\BloomFilter\Hash\Hash;
 use RocketLabs\BloomFilter\Hash\Murmur;
 use RocketLabs\BloomFilter\Persist\BitPersister;
@@ -81,7 +82,7 @@ class BloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->exactly(3))
             ->method('generate')
-            ->will($this->onConsecutiveCalls(42, 1000, 10048));
+            ->will($this->onConsecutiveCalls('42', '1000', '10048'));
 
         $persister->expects($this->once())
             ->method('setBulk')
@@ -95,7 +96,6 @@ class BloomFilterTest extends TestCase
 
     /**
      * @test
-     * @expectedException \LogicException
      */
     public function filterHasNotBeenInitialized()
     {
@@ -108,6 +108,7 @@ class BloomFilterTest extends TestCase
         $persister->expects($this->never())
             ->method('setBulk');
 
+        $this->expectException(NotInitialized::class);
 
         $filter = new BloomFilter($persister, $hash);
         $filter->add('testString');
@@ -122,7 +123,7 @@ class BloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->exactly(9))
             ->method('generate')
-            ->will( $this->onConsecutiveCalls(42, 43, 44, 1, 2, 3, 10001, 10002, 10003));
+            ->will( $this->onConsecutiveCalls('42', '43', '44', '1', '2', '3', '10001', '10002', '10003'));
 
         $persister->expects($this->once())
             ->method('setBulk')
@@ -149,7 +150,7 @@ class BloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->any())
             ->method('generate')
-            ->will( $this->onConsecutiveCalls(42, 1000, 10001, 42, 1000, 10001));
+            ->will( $this->onConsecutiveCalls('42', '1000', '10001', '42', '1000', '10001'));
 
         $persister->expects($this->once())
             ->method('setBulk')
@@ -179,7 +180,7 @@ class BloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->any())
             ->method('generate')
-            ->will( $this->onConsecutiveCalls(42, 1000, 10001, 42, 1000, 10001));
+            ->will( $this->onConsecutiveCalls('42', '1000', '10001', '42', '1000', '10001'));
 
         $persister->expects($this->once())
             ->method('setBulk')
@@ -218,7 +219,7 @@ class BloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->exactly(6))
             ->method('generate')
-            ->will( $this->onConsecutiveCalls(42, 1000, 10048, 43, 1001, 10049));
+            ->will( $this->onConsecutiveCalls('42', '1000', '10048', '43', '1001', '10049'));
 
         $filterForSet = new BloomFilter($persister, $hash);
         $filterForSet->setSize(1024)->setFalsePositiveProbability(0.1);

--- a/tests/CountingBloomFilterTest.php
+++ b/tests/CountingBloomFilterTest.php
@@ -32,7 +32,7 @@ class CountingBloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->exactly(3))
             ->method('generate')
-            ->will($this->onConsecutiveCalls(42, 1000, 10048));
+            ->will($this->onConsecutiveCalls('42', '1000', '10048'));
 
 
 
@@ -62,7 +62,7 @@ class CountingBloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->exactly(3))
             ->method('generate')
-            ->will($this->onConsecutiveCalls(42, 1000, 10048));
+            ->will($this->onConsecutiveCalls('42', '1000', '10048'));
 
 
 
@@ -80,7 +80,7 @@ class CountingBloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->exactly(9))
             ->method('generate')
-            ->will($this->onConsecutiveCalls(42, 43, 44, 1, 2, 3, 10001, 10002, 10003));
+            ->will($this->onConsecutiveCalls('42', '43', '44', '1', '2', '3', '10001', '10002', '10003'));
 
         $bitPersister->expects($this->once())
             ->method('unsetBulk')
@@ -112,7 +112,7 @@ class CountingBloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->exactly(9))
             ->method('generate')
-            ->will( $this->onConsecutiveCalls(42, 43, 44, 1, 2, 3, 10001, 10002, 10003));
+            ->will( $this->onConsecutiveCalls('42', '43', '44', '1', '2', '3', '10001', '10002', '10003'));
 
         $bitPersister->expects($this->once())
             ->method('setBulk')
@@ -145,7 +145,7 @@ class CountingBloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->any())
             ->method('generate')
-            ->will( $this->onConsecutiveCalls(42, 1000, 10001, 42, 1000, 10001));
+            ->will( $this->onConsecutiveCalls('42', '1000', '10001', '42', '1000', '10001'));
 
         $persister->expects($this->once())
             ->method('setBulk')
@@ -177,7 +177,7 @@ class CountingBloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->any())
             ->method('generate')
-            ->will( $this->onConsecutiveCalls(42, 1000, 10001, 42, 1000, 10001));
+            ->will( $this->onConsecutiveCalls('42', '1000', '10001', '42', '1000', '10001'));
 
         $persister->expects($this->once())
             ->method('setBulk')
@@ -226,7 +226,7 @@ class CountingBloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->exactly(6))
             ->method('generate')
-            ->will( $this->onConsecutiveCalls(42, 1000, 10048, 43, 1001, 10049));
+            ->will( $this->onConsecutiveCalls('42', '1000', '10048', '43', '1001', '10049'));
 
         $filterForSet = new CountingBloomFilter($persister, $countPersister, $hash);
         $filterForSet->setSize(1024)->setFalsePositiveProbability(0.1);

--- a/tests/DynamicBloomFilterTest.php
+++ b/tests/DynamicBloomFilterTest.php
@@ -19,25 +19,23 @@ class DynamicBloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->any())
             ->method('generate')
-            ->willReturn(2);
+            ->willReturn('2');
 
-        $persister->expects($this->at(0))
+        $persister->expects($this->exactly(10))
             ->method('setBulk')
-            ->willReturn(1)
-            ->with([2, 2, 2]); //calculated bits for hashes
-
-        $persister->expects($this->at(3))
-            ->method('setBulk')
-            ->willReturn(1)
-            ->with([16, 16, 16]); //calculated bits for hashes
-        $persister->expects($this->at(6))
-            ->method('setBulk')
-            ->willReturn(1)
-            ->with([30, 30, 30]); //calculated bits for hashes
-        $persister->expects($this->at(9))
-            ->method('setBulk')
-            ->willReturn(1)
-            ->with([44, 44, 44]); //calculated bits for hashes
+            ->withConsecutive(
+                [[2, 2, 2]],
+                    [[2, 2, 2]],
+                    [[16, 16, 16]],
+                    [[16, 16, 16]],
+                    [[16, 16, 16]],
+                    [[30, 30, 30]],
+                    [[30, 30, 30]],
+                    [[30, 30, 30]],
+                    [[44, 44, 44]],
+                    [[44, 44, 44]]
+            )
+        ->willReturn(1);
 
         $filter = new DynamicBloomFilter($persister, $hash);
         $filter->setSize(3)->setFalsePositiveProbability(0.1);
@@ -55,7 +53,7 @@ class DynamicBloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->any())
             ->method('generate')
-            ->willReturn(2);
+            ->willReturn('2');
 
         $filter = new DynamicBloomFilter($persister, $hash);
         $filter->setSize(3)->setFalsePositiveProbability(0.1);
@@ -63,8 +61,16 @@ class DynamicBloomFilterTest extends TestCase
             $filter->add('testString');
         }
 
-        $persister->expects($this->at(0))->method('getBulk')->willReturn([1, 0, 1])->with([2, 2 , 2]);
-        $persister->expects($this->at(1))->method('getBulk')->willReturn([1, 1, 1])->with([16, 16 , 16]);
+        $persister->expects($this->exactly(2))
+            ->method('getBulk')
+            ->willReturnOnConsecutiveCalls(
+                [1, 0, 1],
+                [1, 1, 1]
+            )
+            ->withConsecutive(
+                [[2, 2, 2]],
+                [[16, 16, 16]]
+            );
 
         static::assertTrue($filter->has('testString'));
     }
@@ -78,7 +84,7 @@ class DynamicBloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->any())
             ->method('generate')
-            ->willReturn(2);
+            ->willReturn('2');
 
         $filter = new DynamicBloomFilter($persister, $hash);
         $filter->setSize(3)->setFalsePositiveProbability(0.1);
@@ -86,8 +92,16 @@ class DynamicBloomFilterTest extends TestCase
             $filter->add('testString');
         }
 
-        $persister->expects($this->at(0))->method('getBulk')->willReturn([1, 0, 1])->with([2, 2 , 2]);
-        $persister->expects($this->at(1))->method('getBulk')->willReturn([1, 1, 1])->with([16, 16 , 16]);
+        $persister->expects($this->exactly(2))
+            ->method('getBulk')
+            ->willReturnOnConsecutiveCalls(
+                [1, 0, 1],
+                [1, 1, 1]
+            )
+            ->withConsecutive(
+                [[2, 2, 2]],
+                [[16, 16, 16]]
+            );
 
         $memento = $filter->saveState();
 
@@ -106,7 +120,7 @@ class DynamicBloomFilterTest extends TestCase
         $hash = $this->getMockBuilder(Hash::class)->getMock();
         $hash->expects($this->any())
             ->method('generate')
-            ->willReturn(2);
+            ->willReturn('2');
 
         $filter = new DynamicBloomFilter($persister, $hash);
         $filter->setSize(3)->setFalsePositiveProbability(0.1);
@@ -114,10 +128,20 @@ class DynamicBloomFilterTest extends TestCase
             $filter->add('testString');
         }
 
-        $persister->expects($this->at(0))->method('getBulk')->willReturn([1, 0, 1])->with([2, 2 , 2]);
-        $persister->expects($this->at(1))->method('getBulk')->willReturn([1, 1, 0])->with([16, 16, 16]);
-        $persister->expects($this->at(2))->method('getBulk')->willReturn([1, 1, 0])->with([30, 30, 30]);
-        $persister->expects($this->at(3))->method('getBulk')->willReturn([1, 1, 0])->with([44, 44, 44]);
+        $persister->expects($this->exactly(4))
+            ->method('getBulk')
+            ->willReturnOnConsecutiveCalls(
+                [1, 0, 1],
+                [1, 1, 0],
+                [1, 1, 0],
+                [1, 1, 0]
+            )
+            ->withConsecutive(
+                [[2, 2, 2]],
+                [[16, 16, 16]],
+                [[30, 30, 30]],
+                [[44, 44, 44]]
+            );
 
         static::assertFalse($filter->has('testString'));
     }

--- a/tests/Persist/BitRedisTest.php
+++ b/tests/Persist/BitRedisTest.php
@@ -3,6 +3,7 @@
 namespace RocketLabs\BloomFilter\Test\Persist;
 
 use PHPUnit\Framework\TestCase;
+use RocketLabs\BloomFilter\Exception\InvalidValue;
 use RocketLabs\BloomFilter\Persist\BitRedis;
 
 class BitRedisTest extends TestCase
@@ -55,39 +56,44 @@ class BitRedisTest extends TestCase
 
     /**
      * @test
-     * @expectedException \LogicException
      */
     public function setNegativeBit()
     {
         $redisMock = $this->getMockBuilder(\Redis::class)->getMock();
         /** @var \Redis $redisMock */
         $persister = new BitRedis($redisMock, BitRedis::DEFAULT_KEY);
+
+        $this->expectException(InvalidValue::class);
+
         $persister->set(-1);
     }
 
     /**
      * @test
-     * @expectedException \LogicException
      */
     public function getNegativeBit()
     {
         $redisMock = $this->getMockBuilder(\Redis::class)->getMock();
         /** @var \Redis $redisMock */
         $persister = new BitRedis($redisMock, BitRedis::DEFAULT_KEY);
-        $persister->set(-1);
-        $persister->set(-1);
+
+        $this->expectException(InvalidValue::class);
+
+        $persister->get(-1);
 
     }
 
     /**
      * @test
-     * @expectedException \TypeError
      */
     public function getWrongBitValue()
     {
         $redisMock = $this->getMockBuilder(\Redis::class)->getMock();
         /** @var \Redis $redisMock */
         $persister = new BitRedis($redisMock, BitRedis::DEFAULT_KEY);
+
+        $this->expectException(\TypeError::class);
+
         $persister->set('test');
     }
 

--- a/tests/Persist/BitStringTest.php
+++ b/tests/Persist/BitStringTest.php
@@ -3,7 +3,9 @@
 namespace RocketLabs\BloomFilter\Test\Persist;
 
 use PHPUnit\Framework\TestCase;
+use RocketLabs\BloomFilter\Exception\InvalidValue;
 use RocketLabs\BloomFilter\Persist\BitString;
+use TypeError;
 
 class BitStringTest extends TestCase
 {
@@ -77,21 +79,25 @@ class BitStringTest extends TestCase
 
     /**
      * @test
-     * @expectedException \LogicException
      */
     public function setNegativeBit()
     {
         $persister = new BitString();
+
+        $this->expectException(InvalidValue::class);
+
         $persister->set(-1);
     }
 
     /**
      * @test
-     * @expectedException \TypeError
      */
     public function getWrongBitValue()
     {
         $persister = new BitString();
+
+        $this->expectException(TypeError::class);
+
         $persister->set('test');
     }
 

--- a/tests/Persist/CountRedisTest.php
+++ b/tests/Persist/CountRedisTest.php
@@ -3,6 +3,7 @@
 namespace RocketLabs\BloomFilter\Test\Persist;
 
 use PHPUnit\Framework\TestCase;
+use RocketLabs\BloomFilter\Exception\InvalidCounter;
 use RocketLabs\BloomFilter\Persist\CountRedis;
 
 class CountRedisTest extends TestCase
@@ -70,6 +71,9 @@ class CountRedisTest extends TestCase
             ->with(CountRedis::DEFAULT_KEY, 100, 0);
         /** @var \Redis $redisMock */
         $persister = new CountRedis($redisMock, CountRedis::DEFAULT_KEY);
+
+        $this->expectException(InvalidCounter::class);
+
         self::assertEquals(0, $persister->decrementBit(100));
     }
 

--- a/tests/Persist/CountStringTest.php
+++ b/tests/Persist/CountStringTest.php
@@ -3,6 +3,7 @@
 namespace RocketLabs\BloomFilter\Test\Persist;
 
 use PHPUnit\Framework\TestCase;
+use RocketLabs\BloomFilter\Exception\MaxLimitPerBitReached;
 use RocketLabs\BloomFilter\Persist\CountString15;
 
 class CountStringTest extends TestCase
@@ -59,11 +60,13 @@ class CountStringTest extends TestCase
 
     /**
      * @test
-     * @expectedException  \RuntimeException
      */
     public function incrementOverflow()
     {
         $persister = new CountString15();
+
+        $this->expectException(MaxLimitPerBitReached::class);
+
         for ($i = 0; $i < 16; $i++) {
             $persister->incrementBit(42);
         }


### PR DESCRIPTION
Bumped version to Php 8 and fixed tests:
`php  vendor/bin/phpunit --verbose ./tests
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.0

........................................................          56 / 56 (100%)

Time: 00:00.015, Memory: 6.00 MB

OK (56 tests, 117 assertions)`